### PR TITLE
Fix link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We've tried to keep this document as short as possible but there is a lot of inf
 
 [Style Guides](#styleguides)
 
-[But, I still have a question!](#but-i=stil-have-a-question)
+[But, I still have a question!](#but-i-still-have-a-question)
 
 
 ## Why should I contribute?


### PR DESCRIPTION
## Summary
- fix the anchor link for the "But, I still have a question!" section in CONTRIBUTING

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_683f5d1729ec832fa9917cd51936729a