### PR TITLE
Fix missing translations in Huraga theme

### DIFF
--- a/src/modules/Theme/html_admin/mod_theme_preset.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_preset.html.twig
@@ -52,7 +52,7 @@
                             </select>
                             {% if presets|length > 1 and current_preset != 'Default' %}
                                 <a href="{{ 'api/admin/theme/preset_delete'|link({ 'code': theme_code, 'preset': current_preset, 'CSRFToken': CSRFToken}) }}" class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}"
-                                   data-api-confirm-btn="Delete"
+                                   data-api-confirm-btn="{{ 'Delete'|trans }}"
                                    data-api-type="danger"
                                    data-api-reload="1">
                                     <svg class="icon">
@@ -105,7 +105,7 @@
 
             //special class "page"
             document.querySelectorAll('#theme-settings select.page').forEach((el) => {
-                el.append(createOptionElement('', 'None'));
+                el.append(createOptionElement('', "{{ 'None'|trans }}"));
                 Object.entries({{ admin.page_get_pairs|json_encode|raw }}).forEach(([key, value]) => {
                     el.append(createOptionElement(key, value));
                 })
@@ -113,7 +113,7 @@
 
             //special class "snippet"
             document.querySelectorAll('#theme-settings select.snippet').forEach((el) => {
-                el.append(createOptionElement('', 'None'));
+                el.append(createOptionElement('',  "{{ 'None'|trans }}"));
                 Object.entries({{ snippets|json_encode|raw }}).forEach(([key, value]) => {
                     el.append(createOptionElement(key, value));
                 })
@@ -121,7 +121,7 @@
 
             //special class "product"
             document.querySelectorAll('#theme-settings select.product').forEach((el) => {
-                el.append(createOptionElement('', 'None'));
+                el.append(createOptionElement('',  "{{ 'None'|trans }}"));
                 Object.entries({{ admin.product_get_pairs|json_encode|raw }}).forEach(([key, value]) => {
                     el.append(createOptionElement(key, value));
                 })

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -77,7 +77,7 @@
                 {% endif %}
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                         data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
-                        aria-expanded="false" aria-label="Toggle navigation">
+                        aria-expanded="false" aria-label="{{ 'Toggle navigation'|trans }}">
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
@@ -239,7 +239,7 @@
                             </div>
                             {% if guest.extension_is_on({"mod":'branding'}) %}
                                 <div class="d-flex justify-content-center">
-                                    <span>Powered by the&nbsp;</span>
+                                    <span>{{ 'Powered by the'|trans }}&nbsp;</span>
                                     <a class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
                                         href="https://fossbilling.org" title="Billing Software"
                                        target="_blank">{{ 'FOSSBilling Community'|trans }}</a>
@@ -260,7 +260,7 @@
         <div class="spinner-border"
              style="width: 4rem; height: 4rem; top: 50%; left: 50%; position: fixed; z-index: 999"></div>
     </div>
-    <noscript>NOTE: Many features on FOSSBilling require Javascript and cookies. You can enable both via your browser's preference settings.</noscript>
+    <noscript>{{ 'NOTE: Many features on FOSSBilling require Javascript and cookies. You can enable both via your browser\'s preference settings.'|trans }}</noscript>
 
     {% endblock %}
 

--- a/src/themes/huraga/html/partial_pagination.html.twig
+++ b/src/themes/huraga/html/partial_pagination.html.twig
@@ -4,7 +4,7 @@
         <li class="page-item {% if not request.page or request.page == 1 %}disabled{% endif %}">
             <a class="page-link"
                href="{% if request.page and request.page != 1 %}?{% for k,v in {}|merge(request)|merge({'page': 1}) %}{{ k }}={{ v }}{% if loop.last == FALSE %}&{% endif %}{% endfor %}{% else %}#{% endif %}"
-               aria-label="First">
+               aria-label="{{ 'First'|trans }}">
                 <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                     <path
                         d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z"/>
@@ -15,7 +15,7 @@
         <li class="page-item {% if not request.page or request.page == 1 %}disabled{% endif %}">
             <a class="page-link"
                href="{% if request.page  and request.page != '1' %}?{% for k,v in {}|merge(request)|merge({'page': request.page - 1}) %}{{ k }}={{ v }}{% if loop.last == FALSE %}&{% endif %}{% endfor %}{% else %}#{% endif %}"
-               aria-label="Previous">
+               aria-label="{{ 'Previous'|trans }}">
                 <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                     <path d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"/>
                 </svg>
@@ -36,7 +36,7 @@
         <li class="page-item {% if request.page == list.pages %}disabled{% endif %}">
             <a class="page-link"
                href="{% if request.page and request.page != list.pages %}?{% for k,v in {}|merge(request)|merge({'page': request.page + 1}) %}{{ k }}={{ v }}{% if loop.last == FALSE %}&{% endif %}{% endfor %}{% elseif not request.page %}?{% for k,v in {}|merge(request)|merge({'page': 2}) %}{{ k }}={{ v }}{% if loop.last == FALSE %}&{% endif %}{% endfor %}{% else %}#{% endif %}"
-               aria-label="Next">
+               aria-label="{{ 'Next'|trans }}">
                 <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                     <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
                 </svg>
@@ -46,7 +46,7 @@
         <li class="page-item {% if request.page == list.pages %} disabled {% endif %}">
             <a class="page-link"
                href="{% if not request.page or request.page != list.pages %}?{% for k,v in {}|merge(request)|merge({'page': list.pages}) %}{{ k }}={{ v }}{% if loop.last == FALSE %}&{% endif %}{% endfor %}{% else %}#{% endif %}"
-               aria-label="Last">
+               aria-label="{{ 'Last'|trans }}">
                 <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                     <path
                         d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z"/>


### PR DESCRIPTION
## Summary
- translate branding footer text
- make delete confirmation button translatable
- use translated 'None' label in theme settings JS

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_683f5e8b2cc8832f90063afe9100e2c7