### PR TITLE
Fix missing client on new order

### DIFF
--- a/src/modules/Order/Controller/Admin.php
+++ b/src/modules/Order/Controller/Admin.php
@@ -74,8 +74,13 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     {
         $api = $this->di['api_admin'];
 
-        $product = $api->product_get(['id' => $_POST['product_id'] ?? null]);
-        $client = $api->client_get(['id' => $_POST['client_id'] ?? null]);
+        try {
+            $product = $api->product_get(['id' => $_POST['product_id'] ?? null]);
+            $client = $api->client_get(['id' => $_POST['client_id'] ?? null]);
+        } catch (\Exception $e) {
+            $this->di['mod_service']('system')->setPendingMessage($e->getMessage());
+            $app->redirect('/order');
+        }
 
         return $app->render('mod_order_new', ['product' => $product, 'client' => $client]);
     }


### PR DESCRIPTION
## Summary
- fix order creation flow when client is missing by redirecting back and displaying a toast message

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_683f5ceba858832f9667a1674c259171