### PR TITLE
Ensure translation filters on twig accessibility text

### DIFF
--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -189,7 +189,7 @@
         <dialog id="learn-reporting">
             <article>
                 <a href="#close"
-                    aria-label="Close"
+                    aria-label="{{ 'Close'|trans }}"
                     class="close"
                     data-target="learn-reporting"
                     onClick="toggleModal(event)">
@@ -204,7 +204,7 @@
                         role="button"
                         data-target="learn-reporting"
                         onClick="toggleModal(event)">
-                        Got it
+                        {{ 'Got it'|trans }}
                     </a>
                 </footer>
             </article>

--- a/src/modules/Cookieconsent/html_client/mod_cookieconsent_index.html.twig
+++ b/src/modules/Cookieconsent/html_client/mod_cookieconsent_index.html.twig
@@ -1,7 +1,7 @@
 <div id="cookie-consent-block" class="container position-fixed bottom-0 left-0 block">
     <div class="rounded-0 mb-0 alert alert-primary alert-dismissible fade show" role="alert">
         {{ guest.cookieconsent_message }}
-        <button id="close-cookie-consent-btn" type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    <button id="close-cookie-consent-btn" type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'Close'|trans }}"></button>
     </div>
 </div>
 <script type="text/javascript">

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -221,7 +221,7 @@
                             <div class="form-group mb-3 mt-3 row">
                                 <label class="col-md-3 col-form-label">{{ 'Currency exchange rate data provider'|trans }}</label>
                                 <div class="col-md-6">
-                                    <select class="form-select" aria-label="Currency data provider selection" name="provider" id="provider_select">
+                                    <select class="form-select" aria-label="{{ 'Currency data provider selection'|trans }}" name="provider" id="provider_select">
                                         <option value="exchangerate-api" selected>ExchangeRate-API</option>
                                         <option value="currency_data_api">Currency Data API</option>
                                         <option value="currencylayer">currencylayer</option>
@@ -240,7 +240,7 @@
                             <div class="form-group mb-3 row">
                                 <label class="col-md-3 col-form-label">{{ 'Automatic sync rate'|trans }}</label>
                                 <div class="col-md-6">
-                                    <select class="form-select" aria-label="Currency data provider selection" name="sync_rate" id="sync_rate">
+                                    <select class="form-select" aria-label="{{ 'Currency data provider selection'|trans }}" name="sync_rate" id="sync_rate">
                                         <option value="auto" id="auto-sync" selected>{{ 'Auto'|trans }}</option>
                                         <option value="never">{{ 'Never'|trans }}</option>
                                         <option value="1d">{{ 'Daily'|trans }}</option>

--- a/src/modules/Email/html_admin/mod_email_history.html.twig
+++ b/src/modules/Email/html_admin/mod_email_history.html.twig
@@ -12,7 +12,7 @@
         <div class="alert alert-primary alert-dismissible fade show mb-3" role="alert">
             <strong>{{ 'Information'|trans }}:</strong> {{ 'Email logging is not enabled. If you want to log sent mails to database, enable it in'|trans }}
                 <a href="{{ 'extension/settings/email'|alink }}"> {{ 'email settings.'|trans }}</a>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'Close'|trans }}"></button>
         </div>
     {% endif %}
 

--- a/src/modules/Email/html_client/mod_email_email.html.twig
+++ b/src/modules/Email/html_client/mod_email_email.html.twig
@@ -19,7 +19,7 @@
                         <span class="d-block"><span class="text-muted me-2">{{ 'To'|trans }}</span>{{ email.recipients }}</span>
                     </div>
                     <div class="d-flex flex-column gap-2">
-                        <div class="btn-group d-flex" role="group" aria-label="Mail Action">
+                        <div class="btn-group d-flex" role="group" aria-label="{{ 'Mail Action'|trans }}">
                             <a class="btn btn-sm btn-outline-secondary email-resend" href="#" data-id="{{ email.id }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Resend'|trans }}">
                                 <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6,5.75L10.25,10H7V16H13.5L15.5,18H7A2,2 0 0,1 5,16V10H1.75L6,5.75M18,18.25L13.75,14H17V8H10.5L8.5,6H17A2,2 0 0,1 19,8V14H22.25L18,18.25Z" /></svg>
                             </a>

--- a/src/modules/Email/html_client/mod_email_index.html.twig
+++ b/src/modules/Email/html_client/mod_email_index.html.twig
@@ -52,7 +52,7 @@
                                                     <span class="d-block"><span class="text-muted me-2">{{ 'To'|trans }}</span>{{ email.recipients }}</span>
                                                 </div>
                                                 <div class="d-flex flex-column gap-2">
-                                                    <div class="btn-group d-flex" role="group" aria-label="Mail Action">
+                                                      <div class="btn-group d-flex" role="group" aria-label="{{ 'Mail Action'|trans }}">
                                                         <a class="btn btn-sm btn-outline-secondary border-end-0" href="{{ 'email'|link }}/{{ email.id }}" data-bs-toggle="tooltip" data-bs-title="{{ 'View'|trans }}">
                                                             <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12,9A3,3 0 0,1 15,12A3,3 0 0,1 12,15A3,3 0 0,1 9,12A3,3 0 0,1 12,9M12,4.5C17,4.5 21.27,7.61 23,12C21.27,16.39 17,19.5 12,19.5C7,19.5 2.73,16.39 1,12C2.73,7.61 7,4.5 12,4.5M3.18,12C4.83,15.36 8.24,17.5 12,17.5C15.76,17.5 19.17,15.36 20.82,12C19.17,8.64 15.76,6.5 12,6.5C8.24,6.5 4.83,8.64 3.18,12Z" /></svg>
                                                         </a>

--- a/src/modules/Embed/html_admin/mod_embed_index.html.twig
+++ b/src/modules/Embed/html_admin/mod_embed_index.html.twig
@@ -21,7 +21,7 @@
                            value='<iframe width="215" height="200" src="{{ 'embed/loginform'|link }}" frameborder="0"></iframe>'>
                     <span class="input-group-text">
                 <span class="link-secondary cursor-pointer clipboard-copy" data-clipboard-target="#client-login-form"
-                      data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                      data-bs-toggle="tooltip" aria-label="{{ 'Copy'|trans }}" data-bs-original-title="{{ 'Copy'|trans }}">
                     <svg class="icon">
                         <use xlink:href="#copy" />
                     </svg>
@@ -36,7 +36,7 @@
                            value='<iframe width="360" height="75" src="{{ 'embed/domainchecker'|link }}" frameborder="0"></iframe>'>
                     <span class="input-group-text">
                 <span class="link-secondary cursor-pointer clipboard-copy" data-clipboard-target="#domain-checker-form"
-                      data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                      data-bs-toggle="tooltip" aria-label="{{ 'Copy'|trans }}" data-bs-original-title="{{ 'Copy'|trans }}">
                     <svg class="icon">
                         <use xlink:href="#copy" />
                     </svg>
@@ -51,7 +51,7 @@
                            value='<iframe width="400" height="310" src="{{ 'embed/contact'|link }}" frameborder="0"></iframe>'>
                     <span class="input-group-text">
                 <span class="link-secondary cursor-pointer clipboard-copy" data-clipboard-target="#contact-us-form"
-                      data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                      data-bs-toggle="tooltip" aria-label="{{ 'Copy'|trans }}" data-bs-original-title="{{ 'Copy'|trans }}">
                     <svg class="icon">
                         <use xlink:href="#copy" />
                     </svg>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
@@ -4,7 +4,7 @@
             <form class="modal-content api-form" method="post" action="admin/formbuilder/update_field" name="field_form{{ field.id }}" data-api-reload="1">
                 <div class="modal-header">
                     <h5 class="modal-title">{{ 'Edit field'|trans }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                 </div>
                 <div class="modal-body">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}">

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -152,7 +152,7 @@
                     <form class="modal-content api-form" method="post" action="{{ 'api/admin/invoice/mark_as_paid'|link({ 'id': invoice.id, 'execute': 1, 'CSRFToken': CSRFToken }) }}" name="transactionForm" data-api-reload="1">
                     <div class="modal-header">
                         <h5 class="modal-title" id="transactionModalLabel">{{ 'Enter Custom Transaction ID'|trans }}:</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                     </div>
                     <div class="modal-body">
                         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}">

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -258,7 +258,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h4 class="modal-title" id="paymentPromptLabel"></h4>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                     </div>
                     <div class="modal-body">
                         <p id="bodyText"></p>

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -166,7 +166,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title fs-5">{{ 'Submit cancellation request'|trans }}</h1>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                         </div>
                         <form action="" method="post" id="cancel-request-form" class="request-cancellation">
                             <div class="modal-body">
@@ -200,7 +200,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title fs-5">{{ 'Submit new support ticket'|trans }}</h1>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                         </div>
                         <form action="" method="post" id="open-ticket-form" class="open-ticket">
                             <div class="modal-body">
@@ -233,7 +233,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title fs-5">{{ 'Submit upgrade request'|trans }}</h1>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                         </div>
                         <form action="" method="post" id="upgrade-request-form" class="request-upgrade">
                             <div class="modal-body">

--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -219,7 +219,7 @@
                                             <textarea id="html-code" rows="1" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot;&nbsp;class=&quot;order-button&quot;&gt;Order Now&lt;/button&gt;</textarea>
                                             <span class="input-group-text align-items-start pt-3">
                                                 <span class="input-group-link cursor-pointer clipboard-copy" data-clipboard-target="#html-code"
-                                                    data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                                                  data-bs-toggle="tooltip" aria-label="{{ 'Copy'|trans }}" data-bs-original-title="{{ 'Copy'|trans }}">
                                                     <svg class="icon">
                                                         <use xlink:href="#copy">
                                                     </svg>
@@ -234,7 +234,7 @@
                                         <textarea id="html-code2" rows="1" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot; class=&quot;order-button" data-product="2"&gt;Order Product#2 Now&lt;/button&gt;</textarea>
                                         <span class="input-group-text align-items-start pt-3">
                                             <span class="input-group-link cursor-pointer clipboard-copy" data-clipboard-target="#html-code2"
-                                                data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                                                data-bs-toggle="tooltip" aria-label="{{ 'Copy'|trans }}" data-bs-original-title="{{ 'Copy'|trans }}">
                                                 <svg class="icon">
                                                     <use xlink:href="#copy">
                                                 </svg>
@@ -255,7 +255,7 @@
                             <textarea id="script-code" rows="3" class="form-control" onclick="$(this).trigger('select')"></textarea>
                             <span class="input-group-text align-items-start pt-3">
                                 <span class="input-group-link cursor-pointer clipboard-copy" data-clipboard-target="#script-code"
-                                      data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                                      data-bs-toggle="tooltip" aria-label="{{ 'Copy'|trans }}" data-bs-original-title="{{ 'Copy'|trans }}">
                                     <svg class="icon">
                                         <use xlink:href="#copy">
                                     </svg>

--- a/src/modules/Serviceapikey/html_admin/mod_serviceapikey_config.html.twig
+++ b/src/modules/Serviceapikey/html_admin/mod_serviceapikey_config.html.twig
@@ -41,7 +41,7 @@
                 <P>{{ 'Here you can configure what case you want the API keys to be generated with. "Uppercase" makes all letters uppercase, "lowercase" makes them all lowercase, and "mixed" does a combination of the two options.'|trans }}</p>
                 <label class="form-label col-3 col-form-label">{{ 'API key capitalization'|trans }}:</label>
                 <div class="col">
-                    <select class="form-select" aria-label="API key capitalization options" name="config[case]">
+                    <select class="form-select" aria-label="{{ 'API key capitalization options'|trans }}" name="config[case]">
                         <option {% if product.config.case is not defined or product.config.case == "upper" %} selected {% endif %} value="upper">{{ 'Uppercase'|trans }}</option>
                         <option {% if product.config.case == "lower" %} selected {% endif %} value="lower">{{ 'Lowercase'|trans }}</option>
                         <option {% if product.config.case == "mixed" %} selected {% endif %} value="mixed">{{ 'Mixed'|trans }}</option>

--- a/src/modules/Serviceapikey/html_admin/mod_serviceapikey_manage.html.twig
+++ b/src/modules/Serviceapikey/html_admin/mod_serviceapikey_manage.html.twig
@@ -68,7 +68,7 @@
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'API key capitalization'|trans }}:</label>
             <div class="col">
-                <select class="form-select" aria-label="API key capitalization options" name="config[case]">
+                <select class="form-select" aria-label="{{ 'API key capitalization options'|trans }}" name="config[case]">
                     <option {% if request.config.case|default(service.config.case) == "upper" %} selected {% endif %} value="upper">{{ 'Uppercase'|trans }}</option>
                     <option {% if request.config.case|default(service.config.case) == "lower" %} selected {% endif %} value="lower">{{ 'Lowercase'|trans }}</option>
                     <option {% if request.config.case|default(service.config.case) == "mixed" %} selected {% endif %} value="mixed">{{ 'Mixed'|trans }}</option>

--- a/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
@@ -5,7 +5,7 @@
                 <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="modal-header">
                     <h5 class="modal-title">{{ 'Create New Helpdesk'|trans }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                 </div>
                 <div class="modal-body">
                     <div class="form-group mb-3 row">

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -79,7 +79,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h6 class="modal-title">{{ 'Open new ticket'|trans }}</h6>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
             </div>
             <form action="" method="post" id="ticket-submit" class="form" style="background: none">
                 <div class="modal-body">

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -590,7 +590,7 @@ ZW=Zimbabwe
                             
                             <div class="col-12 col-lg-3">
                                 <label for="interface">{{"Select the default network interface:"|trans }}</label>
-                                <select class="form-select" aria-label="Available network interfaces" name="interface" id="interface">
+                                <select class="form-select" aria-label="{{ 'Available network interfaces'|trans }}" name="interface" id="interface">
                                     <option value="0" {% if constant('BIND_TO') == 0 %} selected {%endif%}>{{ 'None (Default PHP Behavior)'|trans }}</option>
                                     {% for i, interface in interface_ips %}
                                     <option value="{{ interface }}" {% if constant('BIND_TO') == interface %} selected {% endif %}>{{ interface }}</option>

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -49,7 +49,7 @@
             <header class="navbar navbar-expand-lg navbar-light d-print-none">
                <div class="container-xl">
                    <div class="d-flex gap-3 align-items-center">
-                       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
+                       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="{{ 'Toggle navigation'|trans }}">
                            <span class="navbar-toggler-icon"></span>
                        </button>
                        <h1 class="d-none d-sm-flex navbar-brand d-none-navbar-horizontal pe-0 pe-md-3 a">
@@ -110,7 +110,7 @@
                         <a class="nav-link d-flex lh-1 text-reset p-0"
                            href="{{ 'staff/profile'|alink }}"
                            data-bs-toggle="dropdown"
-                           aria-label="Open user menu"
+                           aria-label="{{ 'Open user menu'|trans }}"
                            aria-expanded="false">
                            <span class="avatar avatar-sm" style="background-image: url({{ profile.email|gravatar }}&size=32)"></span>
                            <div class="d-none d-xl-block ps-2">
@@ -193,7 +193,7 @@
             </nav>
             <main class="page-body">
                 <div class="container-xl">
-                    <nav class="mb-3" aria-label="breadcrumb">
+                    <nav class="mb-3" aria-label="{{ 'breadcrumb'|trans }}">
                         {% block breadcrumbs %}
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item">
@@ -229,7 +229,7 @@
         {% include '../build/symbol/icons-sprite.svg' %}
     </div>
 
-    <button type="button" aria-label="Back to top" class="btn btn-floating btn-lg btn-icon hidden" id="back-to-top">
+    <button type="button" aria-label="{{ 'Back to top'|trans }}" class="btn btn-floating btn-lg btn-icon hidden" id="back-to-top">
         <svg class="icon">
             <use xlink:href="#arrow-up" />
         </svg>

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -17,26 +17,26 @@
             </div>
         {% endif %}
         {% if alert.dismissible %}
-            <a class="btn-close" data-bs-dismiss="alert" aria-label="close"></a>
+            <a class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'Close'|trans }}"></a>
         {% endif %}
     </div>
     {% endfor %}
     {% for msg in admin.system_messages({ 'type': 'danger' }) %}
     <div class="alert alert-danger alert-dismissible fade show mb-3" role="alert">
         <strong>{{ 'Danger!'|trans }}</strong> {% if msg.url is not empty %}<a href="{{ msg.url }}">{{ msg.text }}</a>{% else %} {{ msg.text }} {% endif %}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'Close'|trans }}"></button>
     </div>
     {% endfor %}
     {% for msg in admin.system_messages({ 'type': 'warning' }) %}
     <div class="alert alert-warning alert-dismissible fade show mb-3" role="alert">
         <strong>{{ 'Warning'|trans }}:</strong> {% if msg.url is not empty %}<a href="{{ msg.url }}">{{ msg.text }}</a>{% else %} {{ msg.text }} {% endif %}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'Close'|trans }}"></button>
     </div>
     {% endfor %}
     {% for msg in admin.system_messages({ 'type': 'info' }) %}
     <div class="alert alert-primary alert-dismissible fade show mb-3" role="alert">
         <strong>{{ 'Information'|trans }}:</strong> {% if msg.url is not empty %}<a href="{{ msg.url }}">{{ msg.text }}</a>{% else %} {{ msg.text }} {% endif %}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'Close'|trans }}"></button>
     </div>
     {% endfor %}
 

--- a/src/themes/admin_default/html/partial_extensions.html.twig
+++ b/src/themes/admin_default/html/partial_extensions.html.twig
@@ -10,7 +10,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="extension-name"></h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
                 </div>
                 <div id="extension-readme" class="modal-body">
                 </div>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -163,7 +163,7 @@
                         <div class="content-block" role="main">
                             {% if settings.show_breadcrumb %}
                                 {% block breadcrumbs %}
-                                    <nav aria-label="breadcrumb">
+                                    <nav aria-label="{{ 'breadcrumb'|trans }}">
                                         <ol class="breadcrumb d-none d-md-flex">
                                             <li class="breadcrumb-item"><a href="{{ '/'|link }}">{{ 'Home'|trans }}</a>
                                             </li>


### PR DESCRIPTION
## Summary
- translate button aria-labels and tooltip text across twig templates
- ensure "Got it" button from installer uses trans filter
- localize breadcrumb labels and navigation attributes

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff881b08c832fbde07245ae1e7364